### PR TITLE
Compute font size in onMeasure() to support height, line spacing, drawables, etc.

### DIFF
--- a/library/src/main/java/me/grantland/widget/AutofitTextView.java
+++ b/library/src/main/java/me/grantland/widget/AutofitTextView.java
@@ -296,11 +296,19 @@ public class AutofitTextView extends TextView {
             super.setMaxHeight(Integer.MAX_VALUE);
         }
         super.setEllipsize(null);
+        Drawable background = getBackground();
+        if (background != null) {
+            setBackgroundDrawable(null);
+        }
+
         // Find correct font size
         final float size = findTextSize(1.0f, mTextSize, targetHeight, maxLines, widthMeasureSpec,
                                         parentHeightMeasureSpec);
 
         // Restore state
+        if (background != null) {
+            setBackgroundDrawable(null);
+        }
         super.setEllipsize(mEllipsize);
         if (maxLines > 0) {
             super.setMaxLines(maxLines);

--- a/library/src/main/java/me/grantland/widget/AutofitTextView.java
+++ b/library/src/main/java/me/grantland/widget/AutofitTextView.java
@@ -109,6 +109,15 @@ public class AutofitTextView extends TextView {
      * {@inheritDoc}
      */
     @Override
+    public void setTextAppearance(Context context, int resid) {
+        super.setTextAppearance(context, resid);
+        setRawTextSize(super.getTextSize());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public float getTextSize() {
         return mTextSize;
     }

--- a/library/src/main/java/me/grantland/widget/AutofitTextView.java
+++ b/library/src/main/java/me/grantland/widget/AutofitTextView.java
@@ -14,6 +14,7 @@ import me.grantland.autofittextview.R;
  * A TextView that resizes it's text to be no larger than the width of the view.
  *
  * @author Grantland Chew <grantlandchew@gmail.com>
+ * @author David R. Bild <drbild@willbild.com>
  */
 public class AutofitTextView extends TextView {
 

--- a/sample/src/main/res/layout-land/main.xml
+++ b/sample/src/main/res/layout-land/main.xml
@@ -58,7 +58,7 @@
                     android:text="@string/example"
                     android:textSize="50sp"
                     android:gravity="center"
-                    android:singleLine="true"
+                    android:maxLines="1"
                     autofit:minTextSize="8sp"
                     />
             </LinearLayout>

--- a/sample/src/main/res/layout/main.xml
+++ b/sample/src/main/res/layout/main.xml
@@ -40,7 +40,7 @@
             android:text="@string/example"
             android:textSize="50sp"
             android:gravity="center"
-            android:singleLine="true"
+            android:maxLines="1"
             autofit:minTextSize="8sp"
             />
     </LinearLayout>


### PR DESCRIPTION
The previous version used a separate StaticLayout to determine if the
text was too large for the desired TextView height.  However,
accurately mimicing the TextView appearance (and thus size) is nearly
impossible when one considers full information, e.g., line spacing,
left/right/top/bottom drawables, replacement spans, etc.  Before API
16, information like line spacing was simply unavailable to
subclasses.

This commit uses a different approach. The onMeasure() method is
overriden to tell the superclass TextView to measure at its desired
height. If this is too tall or short (in pixels or lines), the font is
decreased or increased and the view measured again.  The same binary
search process as before is used.

This commit does not work when the 'android:singleLine' attribute is
set. The text is clipped. Instead, 'android:maxlines="1"' should be
set and the desired ellipsizing, horizontal scrolling, and single-line
transforms set manually.

The TextView treats 'singleLine' as a special case (i.e., it's handled
differently than 'android:maxLines="1"'), but does not expose this
state. Ideally, we would disable 'singleLine' in onMeasure(), before
calling super.onMeasure(), and reenable it after setting the fitted
font size. However, as there is no (supported) way to determine if the
'singleLine' property was set, this is not possible.  Simply disabling
maxLines and ellipsizing does not work---I belive because the TextView
uses the cached internal StaticLayout.

Ultimately, using 'singleLine' in an autosizing text view is weird
anyway, since 'singleLine' implies 'ellipsized'.  (Ellipizing after
the font size has reached the minimum is still supported).