### PR TITLE
Set android:allowBackup="false" to include library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -5,6 +5,6 @@
     android:versionName="1.0" >
 
     <application
-        android:allowBackup="true"/>
+        android:allowBackup="false"/>
 
 </manifest> 


### PR DESCRIPTION
When including your Library in my App I get this error message on gradle build:

Error:(42, 9) Attribute application@allowBackup value=(true) from AndroidManifest.xml:42:9
Error:(42, 9) Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(true) from AndroidManifest.xml:42:9
  	is also present at bills-android:XXXXXX:unspecified:31:9 value=(false)
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:41:5 to override

A Library should never set androidBackup=true in it's manifest, please fix.

Thanks and best regards,
Bedoy