### PR TITLE
Fix #11: stackoverflow for string containing more newLines than maxLines and maxLines > 1

### DIFF
--- a/library/src/main/java/me/grantland/widget/AutofitHelper.java
+++ b/library/src/main/java/me/grantland/widget/AutofitHelper.java
@@ -158,6 +158,10 @@ public class AutofitHelper {
                 " target=" + targetWidth + " maxLines=" + maxLines + " lineCount=" + lineCount);
 
         if (lineCount > maxLines) {
+            // For the case that `text` has more newline characters than `maxLines`.
+            if ((high - low) < precision) {
+                return low;
+            }
             return getAutofitTextSize(text, paint, targetWidth, maxLines, low, mid, precision,
                     displayMetrics);
         }


### PR DESCRIPTION
More performant solution than #25 that doesn't require parsing the entire string.