### PR TITLE
Konradjanica.heightfitting

### DIFF
--- a/library/src/main/java/me/grantland/widget/AutofitHelper.java
+++ b/library/src/main/java/me/grantland/widget/AutofitHelper.java
@@ -61,6 +61,7 @@ public class AutofitHelper {
     public static AutofitHelper create(TextView view, AttributeSet attrs, int defStyle) {
         AutofitHelper helper = new AutofitHelper(view);
         boolean sizeToFit = true;
+        boolean heightToFit = false;
         if (attrs != null) {
             Context context = view.getContext();
             int minTextSize = (int) helper.getMinTextSize();
@@ -72,6 +73,7 @@ public class AutofitHelper {
                     defStyle,
                     0);
             sizeToFit = ta.getBoolean(R.styleable.AutofitTextView_sizeToFit, sizeToFit);
+            heightToFit = ta.getBoolean(R.styleable.AutofitTextView_heightToFit, heightToFit);
             minTextSize = ta.getDimensionPixelSize(R.styleable.AutofitTextView_minTextSize,
                     minTextSize);
             precision = ta.getFloat(R.styleable.AutofitTextView_precision, precision);
@@ -80,6 +82,7 @@ public class AutofitHelper {
             helper.setMinTextSize(TypedValue.COMPLEX_UNIT_PX, minTextSize)
                 .setPrecision(precision);
         }
+        helper.setHeightFitting(heightToFit);
         helper.setEnabled(sizeToFit);
 
         return helper;
@@ -128,11 +131,42 @@ public class AutofitHelper {
                     displayMetrics);
         }
 
-        if (size < minTextSize) {
-            size = minTextSize;
+        if (mIsHeightFitting) {
+            int targetHeight = view.getHeight() - view.getPaddingTop() - view.getPaddingTop();
+            if (targetHeight <= 0) {
+                if (size < minTextSize) {
+                    size = minTextSize;
+                }
+                view.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
+                return;
+            }
+
+            float textHeight = getTextHeight(text, paint, targetWidth, size);
+            textHeight = getTextHeight(text, paint, targetWidth, size);
+            float heightRatio = targetHeight / textHeight;
+            float newSize = size * heightRatio;
+            if (newSize < size) {
+                size = newSize;
+            }
+
+            if (size < minTextSize) {
+                size = minTextSize;
+            }
         }
 
         view.setTextSize(TypedValue.COMPLEX_UNIT_PX, size);
+    }
+
+    /**
+     * Try to fit the text with current size to a static layout to calculate height needed
+     * by that text size.
+     * @note Can be put in a loop where text size is gradually decreased etc.
+     * @return float The height size required by the text.
+     */
+    private static float getTextHeight(CharSequence text, TextPaint paint, int width, float textSize) {
+        StaticLayout textHeightAdjuster = new StaticLayout(text, paint, width,
+                Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, true);
+        return textHeightAdjuster.getHeight();
     }
 
     /**
@@ -234,6 +268,7 @@ public class AutofitHelper {
 
     private boolean mEnabled;
     private boolean mIsAutofitting;
+    private static boolean mIsHeightFitting;
 
     private ArrayList<OnTextSizeChangeListener> mListeners;
 
@@ -418,7 +453,8 @@ public class AutofitHelper {
     }
 
     /**
-     * Returns whether or not automatically resizing text is enabled.
+     * Returns whether or not automatically resizing text
+     * by width and number of lines is enabled.
      */
     public boolean isEnabled() {
         return mEnabled;
@@ -443,6 +479,27 @@ public class AutofitHelper {
                 mTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX, mTextSize);
             }
         }
+        return this;
+    }
+
+    /**
+     * Returns whether or not automatically resizing text
+     * by height is enabled.
+     * @return boolean True when height scaling is on.
+     */
+    public boolean isHeightFitting() {
+        return mIsHeightFitting;
+    }
+
+    /**
+     * Sets the state of automatically resizing by text fitting in height.
+     * Calls an autofit if it is already enabled.
+     * @param enabled The state to update the height fitting member
+     */
+    public AutofitHelper setHeightFitting(boolean enabled) {
+        mIsHeightFitting = enabled;
+        // Fit if required
+        setEnabled(mEnabled);
         return this;
     }
 

--- a/library/src/main/java/me/grantland/widget/AutofitLayout.java
+++ b/library/src/main/java/me/grantland/widget/AutofitLayout.java
@@ -9,6 +9,8 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import com.konradjanica.amatch.R;
+
 import java.util.WeakHashMap;
 
 /**
@@ -22,6 +24,7 @@ import java.util.WeakHashMap;
 public class AutofitLayout extends FrameLayout {
 
     private boolean mEnabled;
+    private boolean mIsHeightFitting;
     private float mMinTextSize;
     private float mPrecision;
     private WeakHashMap<View, AutofitHelper> mHelpers = new WeakHashMap<View, AutofitHelper>();
@@ -43,6 +46,7 @@ public class AutofitLayout extends FrameLayout {
 
     private void init(Context context, AttributeSet attrs, int defStyle) {
         boolean sizeToFit = true;
+        boolean heightToFit = false;
         int minTextSize = -1;
         float precision = -1;
 
@@ -53,13 +57,16 @@ public class AutofitLayout extends FrameLayout {
                     defStyle,
                     0);
             sizeToFit = ta.getBoolean(R.styleable.AutofitTextView_sizeToFit, sizeToFit);
+            heightToFit = ta.getBoolean(R.styleable.AutofitTextView_heightToFit, heightToFit);
             minTextSize = ta.getDimensionPixelSize(R.styleable.AutofitTextView_minTextSize,
                     minTextSize);
             precision = ta.getFloat(R.styleable.AutofitTextView_precision, precision);
             ta.recycle();
         }
 
+
         mEnabled = sizeToFit;
+        mIsHeightFitting = heightToFit;
         mMinTextSize = minTextSize;
         mPrecision = precision;
     }
@@ -68,8 +75,9 @@ public class AutofitLayout extends FrameLayout {
     public void addView(View child, int index, ViewGroup.LayoutParams params) {
         super.addView(child, index, params);
         TextView textView = (TextView) child;
-        AutofitHelper helper = AutofitHelper.create(textView)
-                .setEnabled(mEnabled);
+        AutofitHelper helper = AutofitHelper.create(textView);
+        helper.setHeightFitting(mIsHeightFitting);
+        helper.setEnabled(mEnabled);
         if (mPrecision > 0) {
             helper.setPrecision(mPrecision);
         }

--- a/library/src/main/java/me/grantland/widget/AutofitLayout.java
+++ b/library/src/main/java/me/grantland/widget/AutofitLayout.java
@@ -9,8 +9,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import com.konradjanica.amatch.R;
-
 import java.util.WeakHashMap;
 
 /**

--- a/library/src/main/java/me/grantland/widget/AutofitTextView.java
+++ b/library/src/main/java/me/grantland/widget/AutofitTextView.java
@@ -104,6 +104,29 @@ public class AutofitTextView extends TextView implements AutofitHelper.OnTextSiz
     }
 
     /**
+     * Returns whether or not the text will be automatically re-sized to fit its height.
+     */
+    public boolean isHeightFitting() {
+        return mHelper.isHeightFitting();
+    }
+
+    /**
+     * Sets the property of this field (isHeightFitting), to automatically resize the text to fit
+     * its height.
+     */
+    public void setHeightFitting() {
+        setHeightFitting(true);
+    }
+
+    /**
+     * Enables automatic text resizing to fit the textview height
+     * @param isEnabled If true, the text will automatically be re-sized to fit its height
+     */
+    public void setHeightFitting(boolean isEnabled) {
+        mHelper.setHeightFitting(isEnabled);
+    }
+
+    /**
      * Returns the maximum size (in pixels) of the text in this View.
      */
     public float getMaxTextSize() {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -9,5 +9,7 @@
         <attr name="precision" format="float" />
         <!-- Defines whether to automatically resize text to fit to the view's bounds. -->
         <attr name="sizeToFit" format="boolean" />
+        <!-- Defines whether to automatically resize text to fit to the view's height bounds. -->
+        <attr name="heightToFit" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
https://github.com/grantland/android-autofittextview/issues/19

Adds an option to allow text downsizing to fit height. 

**See methods:**
* *setHeightFitting()*
* *isHeightFitting()*

**See members:**
* isHeightFitting
* heightToFit

Works in project https://github.com/KonradJanica/aMatch

Notes:
* I did it very quickly and AutofitLayout isn't tested but only one line was added.
* mIsHeightFitting is a static member due to autofit() being a static method

P.S. sorry about the entire file change, I think my IDE changed something... I suggest maybe leaving it as a new branch until thoroughly tested.