### PR TITLE
Substituted TextView with AppCompatTextView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,25 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+        maven {
+            url "https://maven.google.com"
+        }
     }
 }
 
 ext {
-    compileSdkVersion = 23
-    buildToolsVersion = "23.0.3"
+    compileSdkVersion = 26
+    buildToolsVersion = "26.0.0"
 
     minSdkVersion = 14
-    targetSdkVersion = 23
+    targetSdkVersion = 26
+
+    support = '26.0.0-beta2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 25 23:12:46 PDT 2016
+#Thu Jun 29 14:29:22 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-rc-1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,4 +10,8 @@ android {
     }
 }
 
+dependencies {
+    compile 'com.android.support:appcompat-v7:' + rootProject.ext.support
+}
+
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/library/src/main/java/me/grantland/widget/AutofitTextView.java
+++ b/library/src/main/java/me/grantland/widget/AutofitTextView.java
@@ -1,6 +1,7 @@
 package me.grantland.widget;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatTextView;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 import android.widget.TextView;
@@ -12,7 +13,9 @@ import android.widget.TextView;
  * @attr ref R.styleable.AutofitTextView_minTextSize
  * @attr ref R.styleable.AutofitTextView_precision
  */
-public class AutofitTextView extends TextView implements AutofitHelper.OnTextSizeChangeListener {
+public class AutofitTextView
+        extends AppCompatTextView
+        implements AutofitHelper.OnTextSizeChangeListener {
 
     private AutofitHelper mHelper;
 
@@ -115,7 +118,6 @@ public class AutofitTextView extends TextView implements AutofitHelper.OnTextSiz
      * is adjusted based on the current density and user font size preference.
      *
      * @param size The scaled pixel size.
-     *
      * @attr ref android.R.styleable#TextView_textSize
      */
     public void setMaxTextSize(float size) {
@@ -128,7 +130,6 @@ public class AutofitTextView extends TextView implements AutofitHelper.OnTextSiz
      *
      * @param unit The desired dimension unit.
      * @param size The desired size in the given units.
-     *
      * @attr ref android.R.styleable#TextView_textSize
      */
     public void setMaxTextSize(int unit, float size) {
@@ -147,7 +148,6 @@ public class AutofitTextView extends TextView implements AutofitHelper.OnTextSiz
      * is adjusted based on the current density and user font size preference.
      *
      * @param minSize The scaled pixel size.
-     *
      * @attr ref me.grantland.R.styleable#AutofitTextView_minTextSize
      */
     public void setMinTextSize(int minSize) {
@@ -158,9 +158,8 @@ public class AutofitTextView extends TextView implements AutofitHelper.OnTextSiz
      * Set the minimum text size to a given unit and value. See TypedValue for the possible
      * dimension units.
      *
-     * @param unit The desired dimension unit.
+     * @param unit    The desired dimension unit.
      * @param minSize The desired size in the given units.
-     *
      * @attr ref me.grantland.R.styleable#AutofitTextView_minTextSize
      */
     public void setMinTextSize(int unit, float minSize) {


### PR DESCRIPTION
I think the library is really useful... but inheriting from TextView limits its usages: extending from AppCompatTextView the AutoFitTextView can benefit of newer attributes for fonts (like app:fontFamily=“…”) and for tints (app:drawableTint="...").

In order to help developers avoid conflicts with the version of the support library they use in their apps, you could edit the readme.md specifying that the library should be imported excluding the support package like this:
```
dependencies {
    compile ('me.grantland:autofittextview:0.2.+') {
        exclude group:'com.android.support'
    }
}
```

Hope it helps! :)